### PR TITLE
Apply patches from esp-idf on protocomm/wpa_supplicant

### DIFF
--- a/components/protocomm/src/security/security1.c
+++ b/components/protocomm/src/security/security1.c
@@ -24,6 +24,7 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/ecdh.h>
 #include <mbedtls/error.h>
+#include <mbedtls/ssl_internal.h>
 #include <mbedtls/constant_time.h>
 
 #include <protocomm_security.h>

--- a/components/protocomm/src/security/security1.c
+++ b/components/protocomm/src/security/security1.c
@@ -24,7 +24,7 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/ecdh.h>
 #include <mbedtls/error.h>
-#include <mbedtls/ssl_internal.h>
+#include <mbedtls/constant_time.h>
 
 #include <protocomm_security.h>
 #include <protocomm_security1.h>
@@ -116,7 +116,7 @@ static esp_err_t handle_session_command1(session_t *cur_session,
     hexdump("Dec Client verifier", check_buf, sizeof(check_buf));
 
     /* constant time memcmp */
-    if (mbedtls_ssl_safer_memcmp(check_buf, cur_session->device_pubkey,
+    if (mbedtls_ct_memcmp(check_buf, cur_session->device_pubkey,
                                  sizeof(cur_session->device_pubkey)) != 0) {
         ESP_LOGE(TAG, "Key mismatch. Close connection");
         mbedtls_aes_free(&cur_session->ctx_aes);

--- a/components/wpa_supplicant/src/crypto/tls_mbedtls.c
+++ b/components/wpa_supplicant/src/crypto/tls_mbedtls.c
@@ -799,9 +799,9 @@ static int tls_connection_prf(void *tls_ctx, struct tls_connection *conn,
 	int ret;
 	u8 seed[2 * TLS_RANDOM_LEN];
 	mbedtls_ssl_context *ssl = &conn->tls->ssl;
-	mbedtls_ssl_transform *transform = ssl->transform;
+	mbedtls_ssl_handshake_params *handshake = ssl->handshake;
 
-	if (!ssl || !transform) {
+	if (!ssl || !handshake) {
 		wpa_printf(MSG_ERROR, "TLS: %s, session ingo is null", __func__);
 		return -1;
 	}
@@ -820,10 +820,10 @@ static int tls_connection_prf(void *tls_ctx, struct tls_connection *conn,
 	wpa_hexdump_key(MSG_MSGDUMP, "random", seed, 2 * TLS_RANDOM_LEN);
 	wpa_hexdump_key(MSG_MSGDUMP, "master", ssl->session->master, TLS_MASTER_SECRET_LEN);
 
-	if (transform->ciphersuite_info->mac == MBEDTLS_MD_SHA384) {
+	if (handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384) {
 		ret = tls_prf_sha384(ssl->session->master, TLS_MASTER_SECRET_LEN,
 				label, seed, 2 * TLS_RANDOM_LEN, out, out_len);
-	} else if (transform->ciphersuite_info->mac == MBEDTLS_MD_SHA256) {
+	} else if (handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256) {
 		ret = tls_prf_sha256(ssl->session->master, TLS_MASTER_SECRET_LEN,
 				label, seed, 2 * TLS_RANDOM_LEN, out, out_len);
 	} else {

--- a/components/wpa_supplicant/src/crypto/tls_mbedtls.c
+++ b/components/wpa_supplicant/src/crypto/tls_mbedtls.c
@@ -74,6 +74,7 @@ struct tls_connection {
 	tls_context_t *tls;
 	struct tls_data tls_io_data;
 	unsigned char randbytes[2 * TLS_RANDOM_LEN];
+	mbedtls_md_type_t mac;
 };
 
 static void tls_mbedtls_cleanup(tls_context_t *tls)
@@ -581,6 +582,7 @@ struct wpabuf * tls_connection_handshake(void *tls_ctx,
 		if (tls->ssl.handshake) {
 			os_memcpy(conn->randbytes, tls->ssl.handshake->randbytes,
 				  TLS_RANDOM_LEN * 2);
+			conn->mac = tls->ssl.handshake->ciphersuite_info->mac;
 		}
 
 		/* trigger state machine multiple times to reach till finish */
@@ -799,9 +801,8 @@ static int tls_connection_prf(void *tls_ctx, struct tls_connection *conn,
 	int ret;
 	u8 seed[2 * TLS_RANDOM_LEN];
 	mbedtls_ssl_context *ssl = &conn->tls->ssl;
-	mbedtls_ssl_handshake_params *handshake = ssl->handshake;
 
-	if (!ssl || !handshake) {
+	if (!ssl || !ssl->transform) {
 		wpa_printf(MSG_ERROR, "TLS: %s, session ingo is null", __func__);
 		return -1;
 	}
@@ -820,10 +821,10 @@ static int tls_connection_prf(void *tls_ctx, struct tls_connection *conn,
 	wpa_hexdump_key(MSG_MSGDUMP, "random", seed, 2 * TLS_RANDOM_LEN);
 	wpa_hexdump_key(MSG_MSGDUMP, "master", ssl->session->master, TLS_MASTER_SECRET_LEN);
 
-	if (handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384) {
+	if (conn->mac == MBEDTLS_MD_SHA384) {
 		ret = tls_prf_sha384(ssl->session->master, TLS_MASTER_SECRET_LEN,
 				label, seed, 2 * TLS_RANDOM_LEN, out, out_len);
-	} else if (handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256) {
+	} else if (conn->mac == MBEDTLS_MD_SHA256) {
 		ret = tls_prf_sha256(ssl->session->master, TLS_MASTER_SECRET_LEN,
 				label, seed, 2 * TLS_RANDOM_LEN, out, out_len);
 	} else {


### PR DESCRIPTION
Apply patches from esp-idf on protocomm/wpa_supplicant based on mbedtls v2.28.0.
- Patch 1: https://github.com/espressif/esp-idf/commit/09de3797318228b2ecea7247c59e1d6865f74937
- Patch 2: https://github.com/espressif/esp-idf/commit/76a29cd68dbe258412e810f27204032ec14b3345

Description for patch 1:
Based on mbedtls v2.28.0, API mbedtls_ssl_safer_memcmp is changed to mbedtls_ct_memcmp, and the header file is also moved to constant_time.h.

Description for patch 2:
Based on mbedtls v2.28.0, ciphersuite_info is moved from structure mbedtls_ssl_transform to mbedtls_ssl_handshake_params.